### PR TITLE
fix: Fix distr fetching on OSX

### DIFF
--- a/sh/as_user.sh
+++ b/sh/as_user.sh
@@ -68,7 +68,7 @@ export HOME="${homedir:-/home/${username}}"
 chown "${username}:$(if [ $use_gid -eq 1 ]; then echo ${gid}; else echo ${groupname}; fi)" "$HOME"
 
 # Skip -l flag for debian which brake build
-distr=$(grep '^ID=' /etc/*-release | cut -d = -f 2)
+distr="$(find /etc/ -maxdepth 1 -name '*-release' -print0 | xargs -0 grep '^ID=' | cut -d = -f 2)"
 case $distr in
   debian) login="" ;;
   *) login="-l" ;;
@@ -79,4 +79,3 @@ if [ -n "$cmd" ]; then
 else
     su "${username}" ${login} -m;
 fi
-


### PR DESCRIPTION
На данный момент `build_utils` невозможно пользоваться на OSX из-за недавних изменений, полагающихся на содержимое `/etc/*-release`
PR содержит необходимые изменения