### PR TITLE
Remove ~/.cache from default mount options

### DIFF
--- a/make_lib/utils_container.mk
+++ b/make_lib/utils_container.mk
@@ -34,7 +34,7 @@ UID = $(shell id -u)
 GNAME = $(shell id -g -n $(UNAME) | tr '[:upper:]' '[:lower:]')
 GID = $(shell id -g)
 DOCKER_RUN_CMD = $(UTILS_PATH)/sh/as_user.sh -u $(UID) -g $(GID)
-DOCKER_RUN_PREFIX += -t -v $$HOME/.cache:/home/$(UNAME)/.cache:rw -v $$HOME/.ssh:/home/$(UNAME)/.ssh:ro
+DOCKER_RUN_PREFIX += -t -v $$HOME/.ssh:/home/$(UNAME)/.ssh:ro
 export UNAME
 
 # Additional options can be passed to 'docker run' via DOCKER_RUN_OPTS


### PR DESCRIPTION
On some CI systems (e.g., Github Actions), the home directory is read-only.