### PR TITLE
Feat/setup fun

### DIFF
--- a/jenkins_lib/setup.groovy
+++ b/jenkins_lib/setup.groovy
@@ -7,3 +7,5 @@ def call(modules, jenkins_lib = null, sh_tools = null) {
         }
     }
 }
+
+return this;

--- a/jenkins_lib/setup.groovy
+++ b/jenkins_lib/setup.groovy
@@ -3,7 +3,7 @@ def call(modules, jenkins_lib = null, sh_tools = null) {
     env.SH_TOOLS = sh_tools ?: env.SH_TOOLS ?: "build_utils/sh"
     modules.each { mod ->
         if (!binding.hasVariable("${mod}")) {
-            evaluate("def ${mod} = load(${env.JENKINS_LIB}/${mod}.groovy)")
+            evaluate("def ${mod} = load(\"${env.JENKINS_LIB}/${mod}.groovy\")")
         }
     }
 }

--- a/jenkins_lib/setup.groovy
+++ b/jenkins_lib/setup.groovy
@@ -1,9 +1,10 @@
-def call(modules, jenkins_lib = null, sh_tools = null) {
+def call(List modules, String jenkins_lib = "", String sh_tools = "") {
     env.JENKINS_LIB = jenkins_lib ?: env.JENKINS_LIB ?: "build_utils/jenkins_lib"
     env.SH_TOOLS = sh_tools ?: env.SH_TOOLS ?: "build_utils/sh"
     modules.each { mod ->
         if (!binding.hasVariable("${mod}")) {
-            evaluate("def ${mod} = load(\"${env.JENKINS_LIB}/${mod}.groovy\")")
+            file = "${env.JENKINS_LIB}/${mod}.groovy"
+            evaluate("${mod} = load(\"${file}\")")
         }
     }
 }

--- a/jenkins_lib/setup.groovy
+++ b/jenkins_lib/setup.groovy
@@ -1,0 +1,9 @@
+def call(modules, jenkins_lib: "build_utils/jenkins_lib", sh_tools: "build_utils/sh") {
+    env.JENKINS_LIB = env.JENKINS_LIB ?: jenkins_lib
+    env.SH_TOOLS = env.SH_TOOLS ?: sh_tools
+    modules.each { mod ->
+        if (!binding.hasVariable("${mod}")) {
+            evaluate("def ${mod} = load(${env.JENKINS_LIB}/${mod}.groovy)")
+        }
+    }
+}

--- a/jenkins_lib/setup.groovy
+++ b/jenkins_lib/setup.groovy
@@ -1,6 +1,6 @@
-def call(modules, jenkins_lib: "build_utils/jenkins_lib", sh_tools: "build_utils/sh") {
-    env.JENKINS_LIB = env.JENKINS_LIB ?: jenkins_lib
-    env.SH_TOOLS = env.SH_TOOLS ?: sh_tools
+def call(modules, jenkins_lib = null, sh_tools = null) {
+    env.JENKINS_LIB = jenkins_lib ?: env.JENKINS_LIB ?: "build_utils/jenkins_lib"
+    env.SH_TOOLS = sh_tools ?: env.SH_TOOLS ?: "build_utils/sh"
     modules.each { mod ->
         if (!binding.hasVariable("${mod}")) {
             evaluate("def ${mod} = load(${env.JENKINS_LIB}/${mod}.groovy)")


### PR DESCRIPTION
Добавляет модуль `setup`, который выставляет окружение и подгружает другие требуемые модули.

Позволяет избавиться от многострочников вида:
```groovy
def pipeDefault
def pipeErlangService
def pipeErlangLib
env.JENKINS_LIB = "build_utils/jenkins_lib"
env.SH_TOOLS = "build_utils/sh"
pipeDefault = load("${env.JENKINS_LIB}/pipeDefault.groovy")
pipeErlangService = load("${env.JENKINS_LIB}/pipeErlangService.groovy")
pipeErlangLib = load("${env.JENKINS_LIB}/pipeErlangLib.groovy")
```

В пользу
```groovy
load("build_utils/jenkins_lib/setup.groovy")(
     ["pipeDefault", "pipeErlangService", "pipeErlangLib"])
```
Note: загружает модули в глобальные переменные, но проблемой быть не должно